### PR TITLE
Parse comments in dollar-sign include/run/do file calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 ### Removed
 
+## [1.0.2] - 2018-04-19
+### Changed
+- Allow both local and global Stata macro variables in dynamic path declaration1
+
 ## [1.0.1] - 2018-04-12
 ### Added
 - Support for alternative Stata file imports via `run` and `do`
@@ -17,5 +21,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Initial version of code
 - Initial version of demos
 
-[Unreleased]: https://github.com/VaccineAndDrugEvaluationCentre/code-diary-sas/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/VaccineAndDrugEvaluationCentre/code-diary-sas/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/VaccineAndDrugEvaluationCentre/code-diary-sas/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/VaccineAndDrugEvaluationCentre/code-diary-sas/compare/v1.0.0...v1.0.1

--- a/demo/output-coder.md
+++ b/demo/output-coder.md
@@ -1,6 +1,6 @@
 % Title for output document, just an example (v 1.2.3)
 % Christiaan Righolt, Robert Bisewski, Barret Monchka, Salah Mahmud; Vaccine and Drug Evaluation Centre (VDEC)
-% April 11, 2018
+% April 18, 2018
 
 # Scripts/macros used for project
 * 1: C:\Users\bisewskr\development\code-diary-sas\demo\project_main.sas
@@ -10,6 +10,7 @@
 * 1.2.2: &macro_root.convert_markdown_to_html.sas
 * 1.s1: &demo_root.project_stata.do
 * 1.s1.s16: &demo_root\stata_husk_a.do
+* 1.s1.s16.s6: &demo_root/stata_husk_d.do
 * 1.s1.s17: &demo_root\stata_husk_b.do
 * 1.s1.s18: &demo_root\stata_husk_c.do
 
@@ -58,7 +59,7 @@
 * 1.s1:6 Just an example of Stata comments
 * 1.s1:13 A one-line Stata command
 * 1.s1:15 Test the include/run/do parsing
-* 1.s1.s16:5 This file husk does nothing except help with testing the `include` call...
+* 1.s1.s16:8 This file husk does nothing except help with testing the `include` call...
+* 1.s1.s16.s6:1 This file husk does nothing except help with dollar-sign globals...
 * 1.s1.s17:1 This file husk does nothing except help with testing the `run` call...
 * 1.s1.s18:1 This file husk does nothing except help with testing the `do` call...
-

--- a/demo/output-coder.md
+++ b/demo/output-coder.md
@@ -1,6 +1,6 @@
 % Title for output document, just an example (v 1.2.3)
 % Christiaan Righolt, Robert Bisewski, Barret Monchka, Salah Mahmud; Vaccine and Drug Evaluation Centre (VDEC)
-% April 18, 2018
+% April 19, 2018
 
 # Scripts/macros used for project
 * 1: C:\Users\bisewskr\development\code-diary-sas\demo\project_main.sas

--- a/demo/output-for-all.htm
+++ b/demo/output-for-all.htm
@@ -10,7 +10,7 @@
 <div id="header">
 <h1 class="title-data">Title for output document, just an example (v 1.2.3)</h1>
 <h2 class="title-data">Christiaan Righolt, Robert Bisewski, Barret Monchka, Salah Mahmud; Vaccine and Drug Evaluation Centre (VDEC)</h2>
-<h2 class="title-data">April 11, 2018</h2>
+<h2 class="title-data">April 18, 2018</h2>
 </div>
 <div id="TOC">
 <ul class="toc">
@@ -81,6 +81,7 @@ The Milkyway has stars, this is a test for a single-line two star that is append
 <li>A one-line Stata command</li>
 <li>Test the include/run/do parsing</li>
 <li>This file husk does nothing except help with testing the `include` call...</li>
+<li>This file husk does nothing except help with dollar-sign globals...</li>
 <li>This file husk does nothing except help with testing the `run` call...</li>
 <li>This file husk does nothing except help with testing the `do` call...</li>
 </ul>

--- a/demo/output-for-all.htm
+++ b/demo/output-for-all.htm
@@ -10,7 +10,7 @@
 <div id="header">
 <h1 class="title-data">Title for output document, just an example (v 1.2.3)</h1>
 <h2 class="title-data">Christiaan Righolt, Robert Bisewski, Barret Monchka, Salah Mahmud; Vaccine and Drug Evaluation Centre (VDEC)</h2>
-<h2 class="title-data">April 18, 2018</h2>
+<h2 class="title-data">April 19, 2018</h2>
 </div>
 <div id="TOC">
 <ul class="toc">

--- a/demo/output-for-all.md
+++ b/demo/output-for-all.md
@@ -1,6 +1,6 @@
 % Title for output document, just an example (v 1.2.3)
 % Christiaan Righolt, Robert Bisewski, Barret Monchka, Salah Mahmud; Vaccine and Drug Evaluation Centre (VDEC)
-% April 11, 2018
+% April 18, 2018
 
 # Exclusion criteria
 
@@ -45,6 +45,6 @@
 * A one-line Stata command
 * Test the include/run/do parsing
 * This file husk does nothing except help with testing the `include` call...
+* This file husk does nothing except help with dollar-sign globals...
 * This file husk does nothing except help with testing the `run` call...
 * This file husk does nothing except help with testing the `do` call...
-

--- a/demo/output-for-all.md
+++ b/demo/output-for-all.md
@@ -1,6 +1,6 @@
 % Title for output document, just an example (v 1.2.3)
 % Christiaan Righolt, Robert Bisewski, Barret Monchka, Salah Mahmud; Vaccine and Drug Evaluation Centre (VDEC)
-% April 18, 2018
+% April 19, 2018
 
 # Exclusion criteria
 

--- a/demo/stata_husk_a.do
+++ b/demo/stata_husk_a.do
@@ -2,5 +2,8 @@
 //
 // global F8 "do "P:\commond\source\main.do""
 
+// this tests the DEMO_ROOT global
+do $demo_root/stata_husk_d.do
+
 **@stata This file husk does nothing except help with testing the `include` call...;
 di "attempting to call an include"

--- a/demo/stata_husk_d.do
+++ b/demo/stata_husk_d.do
@@ -1,0 +1,2 @@
+**@stata This file husk does nothing except help with dollar-sign globals...;
+di "this file is imported in stata_husk_a.do"

--- a/source/code_diary.sas
+++ b/source/code_diary.sas
@@ -855,7 +855,8 @@ Copyright (c) 2016 Vaccine and Drug Evaluation Centre, Winnipeg.
 		%let prx_grab_stata_file = 's/^[\s\/\*]*(include|run|do)"?[ \t]+"?([^"]+\.do)"*/$2/';
 
 		* Regex to grab the included script name;
-		%let prx_stata_to_sas_macro = "s/`(\w+)'/&$1/";
+		%let prx_stata_local_to_sas_macro = "s/`(\w+)'/&$1/";
+		%let prx_stata_global_to_sas_macro = "s/\$(\w+)/&$1/";
 
 		* Find stata files called from stata;
 		%if "&input_file_type." = "do" %then %do;
@@ -872,8 +873,8 @@ Copyright (c) 2016 Vaccine and Drug Evaluation Centre, Winnipeg.
 
 				script_no = ("&curr_script_no." || ".s" || strip(put(_N_, &len_script_no..)));
 				script = prxchange(&prx_grab_stata_file., -1, source_line);
-				script = prxchange(&prx_stata_to_sas_macro., -1, script);
-				script = prxchange('s/\$(\w+)/&$1/', -1, script);
+				script = prxchange(&prx_stata_local_to_sas_macro., -1, script);
+				script = prxchange(&prx_stata_global_to_sas_macro., -1, script);
 
 				drop line_no source_line;
 			run;

--- a/source/code_diary.sas
+++ b/source/code_diary.sas
@@ -855,7 +855,7 @@ Copyright (c) 2016 Vaccine and Drug Evaluation Centre, Winnipeg.
 		%let prx_grab_stata_file = 's/^[\s\/\*]*(include|run|do)"?[ \t]+"?([^"]+\.do)"*/$2/';
 
 		* Regex to grab the included script name;
-		%let prx_stata_to_sas_macro = "s/[\$`](\w+)'?/&$1/";
+		%let prx_stata_to_sas_macro = "s/`(\w+)'/&$1/";
 
 		* Find stata files called from stata;
 		%if "&input_file_type." = "do" %then %do;
@@ -873,6 +873,7 @@ Copyright (c) 2016 Vaccine and Drug Evaluation Centre, Winnipeg.
 				script_no = ("&curr_script_no." || ".s" || strip(put(_N_, &len_script_no..)));
 				script = prxchange(&prx_grab_stata_file., -1, source_line);
 				script = prxchange(&prx_stata_to_sas_macro., -1, script);
+				script = prxchange('s/\$(\w+)/&$1/', -1, script);
 
 				drop line_no source_line;
 			run;

--- a/source/code_diary.sas
+++ b/source/code_diary.sas
@@ -855,7 +855,7 @@ Copyright (c) 2016 Vaccine and Drug Evaluation Centre, Winnipeg.
 		%let prx_grab_stata_file = 's/^[\s\/\*]*(include|run|do)"?[ \t]+"?([^"]+\.do)"*/$2/';
 
 		* Regex to grab the included script name;
-		%let prx_stata_to_sas_macro = "s/`(\w+)'/&$1/";
+		%let prx_stata_to_sas_macro = "s/[\$`](\w+)'?/&$1/";
 
 		* Find stata files called from stata;
 		%if "&input_file_type." = "do" %then %do;


### PR DESCRIPTION
This branch resolves issue #14, specifically the ability to handle internal Stata calls to defines / lets / globals using the `$` character to set a path, like so:

```
do $DEMO_ROOT/stata_husk_d.do
```

Where `DEMO_ROOT` is a define that resolves to a path like `P:\commond\source`. 

Previously we only supported the `&` and `'` characters in Stata, like so:

```
do &DEMO_ROOT/important_file_1.do
do `DEMO_ROOT'/additional_code_functions.do
```


I have since verified with works on all platforms and coworkers, including on-RAS. Let me know what you think, and feel free to merge it in and close the issue if you are satisfied.